### PR TITLE
Add C23 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@
 EMULATOR = qemu-system-i386
 LINKER   = ld -m elf_i386 -s
 CC       = gcc
-CFLAGS   = -m32 -ffreestanding -fno-pie -Os -c -ggdb -I./lib -I. -std=c17
+CFLAGS   = -m32 -ffreestanding -fno-pie -Os -c -ggdb -I./lib -I. -std=c23
 ASMC     = nasm 
 ASMF     = elf32
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@
 EMULATOR = qemu-system-i386
 LINKER   = ld -m elf_i386 -s
 CC       = gcc
-CFLAGS   = -m32 -ffreestanding -fno-pie -Os -c -ggdb -I./lib -I. -std=c23
+CFLAGS   = -m32 -ffreestanding -fno-pie -Os -c -ggdb -I./lib -I. -std=c2x
 ASMC     = nasm 
 ASMF     = elf32
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ for me to learn operating system things and also to become better at C and Assem
 ## Installation
 
 > [!NOTE]
-> Compilation is only guaranteed on linux with *GCC ISO C17*,
+> Compilation is only guaranteed on linux with *GCC ISO C23*,
 > but it is also possible in Windows with virtualization
 > solutions like WSL (on Windows 11) or hyperV.
 

--- a/fs/core.c
+++ b/fs/core.c
@@ -246,7 +246,7 @@ void fsinit() {
     "\"github.com/ElisStaaf/pearlOS\", feel free to contribute!\n"
     "And with that, enjoy the OS!\n\n"
     "PEARLOS: Elis Staaf <elis.staaf@proton.me>, Nov 2024.\n"
-    "PIDI-OS: Filip Chovanec <???>, Mar 2021.\n"
+    "PIDI-OS: Filip Chovanec <\?\?\?>, Mar 2021.\n"
   );
   file_make("roadmap");
   file_writes(

--- a/kernel/config.h
+++ b/kernel/config.h
@@ -1,4 +1,6 @@
 /*
+Copyright 2025 Elis Staaf
+
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the LICENSE file
 distributed with this work for additional information

--- a/lib/stddef.h
+++ b/lib/stddef.h
@@ -29,7 +29,6 @@ typedef unsigned int uint;
 typedef unsigned short word;
 typedef unsigned char uchar;
 typedef unsigned short ushort;
-typedef unsigned char bool;
 
 /* size_t */
 #ifdef __SIZE_TYPE__


### PR DESCRIPTION
Why would I ever do this? While C23 isn't the standard *yet*, it's going to be soon. And when that happens, I want to have the latest and greatest. And it's no use patching bugs on release day, no! I have included a list of the changes below

## Changes
- [Merge pull request](https://github.com/ElisStaaf/pearlOS/commit/72ffab159b0acd25f7be54612ded4b7c9f7c1309) https://github.com/ElisStaaf/pearlOS/pull/2 [from ElisStaaf/main](https://github.com/ElisStaaf/pearlOS/commit/72ffab159b0acd25f7be54612ded4b7c9f7c1309):
  - Sync the `impl` branch with the `main` branch. 41 commits merged.
- [Switch standard to c23](https://github.com/ElisStaaf/pearlOS/commit/9711d6b271e991fbe6c184aa4aac87b81205670b):
  - Add `-std=c23` to the Makefile and change documentation to align with this change.
- [[duplicate(main)]: reconfig](https://github.com/ElisStaaf/pearlOS/commit/83c8b92c75ba1cfb73b232a3018655a37e3f515a)
  - Copy the main branch in reconfiguring.
- [remove boolean definition](https://github.com/ElisStaaf/pearlOS/commit/d9c6f54e0b9ebbb113d18dcc27e9b32a23475d6a):
  - Remove the boolean definition in `stddef.h` since booleans come predefined in the new version.
- [Fix trigraph](https://github.com/ElisStaaf/pearlOS/commit/0e40eabbe0f1a890bd630a25e52ae46778c07d32):
  - With trigraphs being added "???" doesn't work anymore, change to "\?\?\?".
- [[urgent]: Update makefile to have -std=c2x](https://github.com/ElisStaaf/pearlOS/pull/3/commits/bea1aec1e1a3e69b089ee3fac65e6962f71c0e93):
  - c23 isn't valid -std=x, c2x is.